### PR TITLE
Update of macOS setup scripts for UFS compatibility

### DIFF
--- a/scm/etc/MACOSX_setup.csh
+++ b/scm/etc/MACOSX_setup.csh
@@ -2,37 +2,26 @@
 
 echo "Setting environment variables for SCM-CCPP on MACOSX with clang/gfortran"
 
-setenv CC /usr/local/bin/mpicc
-setenv CXX /usr/local/bin/mpicxx
-setenv F77 /usr/local/bin/mpif77
-setenv F90 /usr/local/bin/mpif90
-setenv FC /usr/local/bin/mpif90
-setenv CPP "/usr/local/bin/mpif90 -E -x f95-cpp-input"
-
-setenv LDFLAGS "-L/usr/local/opt/zlib/lib -L/usr/local/opt/llvm/lib"
-setenv CPPFLAGS "-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-setenv CFLAGS "-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-setenv CXXFLAGS "-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-setenv FFLAGS "-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-setenv FCFLAGS " -I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-
-if (! $?PATH) then
-  setenv PATH "/usr/local/opt/llvm/bin"
-else
-  setenv PATH "/usr/local/opt/llvm/bin:$PATH"
+if (! $?CC) then
+  setenv CC /usr/local/bin/mpicc
 endif
-if (! $?LD_LIBRARY_PATH) then
-  setenv LD_LIBRARY_PATH "/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib"
-else
-  setenv LD_LIBRARY_PATH "/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
+if (! $?CXX) then
+  setenv CXX /usr/local/bin/mpicxx
 endif
-if (! $?DYLD_LIBRARY_PATH) then
-  setenv DYLD_LIBRARY_PATH "/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib"
-else
-  setenv DYLD_LIBRARY_PATH "/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib:$DYLD_LIBRARY_PATH"
+if (! $?F77) then
+  setenv F77 /usr/local/bin/mpif77
 endif
+if (! $?F90) then
+  setenv F90 /usr/local/bin/mpif90
+endif
+if (! $?FC) then
+  setenv FC /usr/local/bin/mpif90
+endif
+setenv CPP "${FC} -E -x f95-cpp-input"
 
-setenv NETCDF /usr/local
+if (! $?NETCDF) then
+  setenv NETCDF /usr/local
+endif
 
 if (! $?BACIO_LIB4) then
   echo "The BACIO_LIB4 environment variable must be set before proceeding."

--- a/scm/etc/MACOSX_setup.sh
+++ b/scm/etc/MACOSX_setup.sh
@@ -2,25 +2,14 @@
 
 echo "Setting environment variables for SCM-CCPP on MACOSX with clang/gfortran"
 
-export CC=/usr/local/bin/mpicc
-export CXX=/usr/local/bin/mpicxx
-export F77=/usr/local/bin/mpif77
-export F90=/usr/local/bin/mpif90
-export FC=/usr/local/bin/mpif90
-export CPP="/usr/local/bin/mpif90 -E -x f95-cpp-input"
+export CC=${CC:-/usr/local/bin/mpicc}
+export CXX=${CXX:-/usr/local/bin/mpicxx}
+export F77=${F77:-/usr/local/bin/mpif77}
+export F90=${F90:-/usr/local/bin/mpif90}
+export FC=${FC:-/usr/local/bin/mpif90}
+export CPP="${FC} -E -x f95-cpp-input"
 
-export LDFLAGS="-L/usr/local/opt/zlib/lib -L/usr/local/opt/llvm/lib"
-export CPPFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-export CFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-export CXXFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-export FFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-export FCFLAGS="-I/usr/local/opt/zlib/include -I/usr/local/opt/llvm/include"
-
-export PATH="/usr/local/opt/llvm/bin${PATH:+:$PATH}"
-export LD_LIBRARY_PATH="/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export DYLD_LIBRARY_PATH="/usr/local/opt/zlib/lib:/usr/local/opt/llvm/lib:${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-
-export NETCDF=/usr/local
+export NETCDF=${NETCDF:-/usr/local}
 
 if [[ -z "${BACIO_LIB4}" ]]
 then


### PR DESCRIPTION
I tested these on my macOS with both gcc+gfortran and clang+gfortran. My clang+gfortran environment has the following flags already set:
```
export PATH="/usr/local/opt/llvm/bin:$PATH"
export CPPFLAGS="-I/usr/local/opt/llvm/include"
export LDFLAGS="-L/usr/local/opt/llvm/lib"
export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
```
For GNU, these are not required.

It would be good if you could test the setup on your machine that was installed according to the GMTB-SCM instructions.

Similar changes for setting/not overwriting the compiler environment variables should be made for UBUNTU and CENTOS imo.